### PR TITLE
i1 sales engine refactor

### DIFF
--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -51,6 +51,11 @@ class ItemRepository
     end
      # returns either [] or instances of Item where the supplied merchant ID matches that supplied
   end
+
+  def inspect
+    "#<#{self.class} #{@merchants.size} rows>"
+  end
+  
 end
 
 if __FILE__ == $0

--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -27,4 +27,8 @@ class MerchantRepository
     end
   end
 
+  def inspect
+    "#<#{self.class} #{@merchants.size} rows>"
+  end
+
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -20,11 +20,11 @@ class SalesEngine
     items_repo_object     = ItemRepository.new(items_array)
     merchants_repo_object = MerchantRepository.new(merchants_array)
 
-    sales_engine    = SalesEngine.new(merchants_repo_object, items_repo_object)
-
-    merchants.all.each do |merchant|
-      merchant.items = items.find_all_by_merchant_id(merchant.id)
+    merchants_repo_object.all.each do |merchant|
+      merchant.items = items_repo_object.find_all_by_merchant_id(merchant.id)
     end
+
+    SalesEngine.new(merchants_repo_object, items_repo_object)
   end
 
   def self.read_items(location)
@@ -36,6 +36,7 @@ class SalesEngine
                                name: item[:name],
                                description: item[:description],
                                unit_price: item[:unit_price],
+                               merchant_id: item[:merchant_id],
                                created_at: item[:created_at],
                                updated_at: item[:updated_at]})
     end

--- a/test/sales_engine_test.rb
+++ b/test/sales_engine_test.rb
@@ -39,7 +39,7 @@ class SalesEngineTest < Minitest::Test
   def test_it_can_read_items_from_a_csv
     items_array = SalesEngine.read_items("./test/test_data/items_stub.csv")
 
-    assert_equal 6, items_array.count
+    assert_equal 8, items_array.count
     assert_kind_of Item, items_array[0]
     assert_equal "Manchette cuir Mathilde", items_array[0].name
   end
@@ -47,13 +47,13 @@ class SalesEngineTest < Minitest::Test
   def test_it_can_read_merchants_from_a_csv
     merchants_array = SalesEngine.read_merchants("./test/test_data/merchants_stub.csv")
 
-    assert_equal 3, merchants_array.count
+    assert_equal 4, merchants_array.count
     assert_kind_of Merchant, merchants_array[0]
     assert_equal "Shopin1901", merchants_array[0].name
   end
 
   def test_it_can_find_items_associated_with_a_merchant
-    merchant = @se.merchants.find_by_id(10)
+    merchant = @se.merchants.find_by_id("10")
     actual = merchant.items
 
     assert_equal 2, actual.count


### PR DESCRIPTION
@kristindiannefoss Update summaries below:
- Added code to the repositories based on the feedback that the Spec harness was providing (overwriting inspect method).
- Revised injection of items to merchants in SalesEngine to use the repo_objects instead of the instance variables since the SE instance has not yet been created at that point.
- Moved SalesEngine creation to the bottom of that same #from_csv method so that the #from_csv call returns a SalesEngine object.
- Updated tests to reflect the updates we made to the stubs.

These changes move Iteration 1 forward, make our tests pass, and allow us to use the spec harness. Unfortunately it looks like the spec harness doesn't like our iteration 0. I'm guessing part of this may be because we're treating IDs as strings. Recommend we merge these changes to i1 and then see if we can work to make the i0 spec harness work.
